### PR TITLE
Support empty topology

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 COMMONENVVAR = GOOS=linux GOARCH=amd64
 BUILDENVVAR = CGO_ENABLED=0
 RUNTIME ?= podman
-REPOOWNER ?= swsehgal
+REPOOWNER ?= k8stopologyawareschedwg
 IMAGENAME ?= device-plugin
 IMAGETAG ?= latest
 

--- a/cmd/deviceplugin/main.go
+++ b/cmd/deviceplugin/main.go
@@ -184,15 +184,20 @@ func main() {
 
 	var devs []*pluginapi.Device
 	for _, devConf := range devsConf {
-		devs = append(devs, &pluginapi.Device{
-			ID:     devConf.ID,
-			Health: devConf.ToHealthy(),
-			Topology: &pluginapi.TopologyInfo{
+		var topo *pluginapi.TopologyInfo
+		if devConf.NUMANode != -1 {
+			topo = &pluginapi.TopologyInfo{
 				Nodes: []*pluginapi.NUMANode{
 					{ID: int64(devConf.NUMANode)},
 				},
-			},
-		})
+			}
+		}
+		dev := &pluginapi.Device{
+			ID:       devConf.ID,
+			Health:   devConf.ToHealthy(),
+			Topology: topo,
+		}
+		devs = append(devs, dev)
 	}
 
 	if len(devs) == 0 {

--- a/config/device_C.json
+++ b/config/device_C.json
@@ -1,0 +1,39 @@
+{
+    "devicename": "tty1",
+    "devices": {
+        "kind-kubetest-control-plane": [
+            {
+                "id": "DevA1",
+                "healthy": true,
+                "numanode": -1 
+            },
+            {
+                "id": "DevA2",
+                "healthy": true,
+                "numanode": -1 
+            },
+            {
+                "id": "DevA3",
+                "healthy": true,
+                "numanode": -1 
+            }
+        ],
+        "*":    [
+            {
+                "id": "DevA1",
+                "healthy": true,
+                "numanode": 0
+            },
+            {
+                "id": "DevA2",
+                "healthy": true,
+                "numanode": 0
+            },
+            {
+                "id": "DevA3",
+                "healthy": true,
+                "numanode": 0
+            }
+        ]
+    }
+}

--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -18,4 +18,5 @@ RUN mkdir -p /etc/devices
 ADD config/devices.json /etc/devices/config.json
 ADD config/device_A.json /etc/devices/example_com_deviceA.json
 ADD config/device_B.json /etc/devices/example_com_deviceB.json
+ADD config/device_C.json /etc/devices/example_com_deviceC.json
 ENTRYPOINT ["/bin/deviceplugin", "--alsologtostderr", "-C", "/etc/devices"]

--- a/manifests/devicepluginA-ds.yaml
+++ b/manifests/devicepluginA-ds.yaml
@@ -14,7 +14,8 @@ spec:
       hostNetwork: true
       containers:
       - name: device-plugin-a-container
-        image: quay.io/swsehgal/device-plugin:latest
+        image: quay.io/k8stopologyawareschedwg/device-plugin:latest
+        imagePullPolicy: IfNotPresent
         env:
         - name: DEVICE_RESOURCE_NAME
           value: "example.com/deviceA"

--- a/manifests/devicepluginB-ds.yaml
+++ b/manifests/devicepluginB-ds.yaml
@@ -14,7 +14,8 @@ spec:
       hostNetwork: true
       containers:
       - name: device-plugin-b-container
-        image: quay.io/swsehgal/device-plugin:latest
+        image: quay.io/k8stopologyawareschedwg/device-plugin:latest
+        imagePullPolicy: IfNotPresent
         env:
         - name: DEVICE_RESOURCE_NAME
           value: "example.com/deviceB"

--- a/manifests/devicepluginC-ds.yaml
+++ b/manifests/devicepluginC-ds.yaml
@@ -14,7 +14,7 @@ spec:
       hostNetwork: true
       containers:
       - name: device-plugin-a-container
-        image: quay.io/aperevalov/device-plugin:latest
+        image: quay.io/k8stopologyawareschedwg/device-plugin:latest
         imagePullPolicy: IfNotPresent
         env:
         - name: DEVICE_RESOURCE_NAME

--- a/manifests/devicepluginC-ds.yaml
+++ b/manifests/devicepluginC-ds.yaml
@@ -1,0 +1,28 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: device-plugin-c-ds
+spec:
+  selector:
+      matchLabels:
+        name: device-plugin-c
+  template:
+    metadata:
+      labels:
+        name: device-plugin-c
+    spec:
+      hostNetwork: true
+      containers:
+      - name: device-plugin-a-container
+        image: quay.io/aperevalov/device-plugin:latest
+        imagePullPolicy: IfNotPresent
+        env:
+        - name: DEVICE_RESOURCE_NAME
+          value: "example.com/deviceC"
+        volumeMounts:
+        - name: kubeletsockets
+          mountPath: /var/lib/kubelet/device-plugins
+      volumes:
+      - name: kubeletsockets
+        hostPath:
+          path: /var/lib/kubelet/device-plugins

--- a/manifests/test-deviceC.yaml
+++ b/manifests/test-deviceC.yaml
@@ -1,0 +1,22 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test-dp-c
+spec:
+  selector:
+      matchLabels:
+        name: test # Label selector that determines which Pods belong to the DaemonSet
+  template:
+    metadata:
+      labels:
+        name: test # Pod template's label selector
+    spec:
+      #hostNetwork: true
+      containers:
+      - name: test-dp-container
+        image: nginx
+        resources:
+          limits:
+            example.com/deviceC: 1
+          requests:
+            example.com/deviceC: 1

--- a/pkg/fakedevice/fakedevice.go
+++ b/pkg/fakedevice/fakedevice.go
@@ -22,7 +22,10 @@ func MakeEnv(resourceName, fpath string, dev pluginapi.Device) map[string]string
 	}, key)
 	key = strings.ToUpper(key)
 
-	val := fmt.Sprintf("%d", dev.Topology.Nodes[0].ID)
+	val := "-1"
+	if dev.Topology != nil && len(dev.Topology.Nodes) != 0 {
+		val = fmt.Sprintf("%d", dev.Topology.Nodes[0].ID)
+	}
 	klog.Infof("Creating environment variables key=%q val=%q", key, val)
 	env[key] = val
 


### PR DESCRIPTION
Initially kubelet interpreted -1 as non-existing topology.
This patch follows the same semantic.

Signed-off-by: Alexey Perevalov <alexey.perevalov@huawei.com>