### PR TITLE
manifests: reference fixed image

### DIFF
--- a/manifests/devicepluginA-ds.yaml
+++ b/manifests/devicepluginA-ds.yaml
@@ -14,7 +14,7 @@ spec:
       hostNetwork: true
       containers:
       - name: device-plugin-a-container
-        image: quay.io/k8stopologyawareschedwg/device-plugin:latest
+        image: quay.io/k8stopologyawareschedwg/sample-device-plugin:v0.1.1
         imagePullPolicy: IfNotPresent
         env:
         - name: DEVICE_RESOURCE_NAME

--- a/manifests/devicepluginB-ds.yaml
+++ b/manifests/devicepluginB-ds.yaml
@@ -14,7 +14,7 @@ spec:
       hostNetwork: true
       containers:
       - name: device-plugin-b-container
-        image: quay.io/k8stopologyawareschedwg/device-plugin:latest
+        image: quay.io/k8stopologyawareschedwg/sample-device-plugin:v0.1.1
         imagePullPolicy: IfNotPresent
         env:
         - name: DEVICE_RESOURCE_NAME

--- a/manifests/devicepluginC-ds.yaml
+++ b/manifests/devicepluginC-ds.yaml
@@ -14,7 +14,7 @@ spec:
       hostNetwork: true
       containers:
       - name: device-plugin-a-container
-        image: quay.io/k8stopologyawareschedwg/device-plugin:latest
+        image: quay.io/k8stopologyawareschedwg/sample-device-plugin:v0.1.1
         imagePullPolicy: IfNotPresent
         env:
         - name: DEVICE_RESOURCE_NAME


### PR DESCRIPTION
Fix the reference to the quay pre-built image, and
avoid floating tag in reference manifests.

Signed-off-by: Francesco Romani <fromani@redhat.com>