### PR TITLE
devicefile update: Move away from using serial ports as devices

### DIFF
--- a/config/device-A-configmap.yaml
+++ b/config/device-A-configmap.yaml
@@ -6,7 +6,6 @@ metadata:
     app: sample-device-plugin
 data:
   example_com_deviceA.yaml: |
-      devicename: tty1
       devices:
         kind-control-plane:
           - id: DevA1

--- a/config/device-B-configmap.yaml
+++ b/config/device-B-configmap.yaml
@@ -6,7 +6,6 @@ metadata:
     app: sample-device-plugin
 data:
   example_com_deviceB.yaml: |
-      devicename: tty2
       devices:
         kind-control-plane:
           - id: DevB1

--- a/config/device-C-configmap.yaml
+++ b/config/device-C-configmap.yaml
@@ -6,7 +6,6 @@ metadata:
     app: sample-device-plugin
 data:
   example_com_deviceC.yaml: |
-      devicename: tty1
       devices:
         kind-control-plane:
           - id: DevA1

--- a/manifests/devicepluginA-ds.yaml
+++ b/manifests/devicepluginA-ds.yaml
@@ -16,7 +16,7 @@ spec:
       hostNetwork: true
       containers:
       - name: device-plugin-a-container
-        image: quay.io/k8stopologyawareschedwg/sample-device-plugin:v0.1.1
+        image: quay.io/k8stopologyawareschedwg/sample-device-plugin:v0.1.2
         imagePullPolicy: IfNotPresent
         env:
         - name: DEVICE_RESOURCE_NAME

--- a/manifests/devicepluginB-ds.yaml
+++ b/manifests/devicepluginB-ds.yaml
@@ -16,7 +16,7 @@ spec:
       hostNetwork: true
       containers:
       - name: device-plugin-b-container
-        image: quay.io/k8stopologyawareschedwg/sample-device-plugin:v0.1.1
+        image: quay.io/k8stopologyawareschedwg/sample-device-plugin:v0.1.2
         imagePullPolicy: IfNotPresent
         env:
         - name: DEVICE_RESOURCE_NAME

--- a/manifests/devicepluginC-ds.yaml
+++ b/manifests/devicepluginC-ds.yaml
@@ -16,7 +16,7 @@ spec:
       hostNetwork: true
       containers:
       - name: device-plugin-a-container
-        image: quay.io/k8stopologyawareschedwg/sample-device-plugin:v0.1.1
+        image: quay.io/k8stopologyawareschedwg/sample-device-plugin:v0.1.2
         imagePullPolicy: IfNotPresent
         env:
         - name: DEVICE_RESOURCE_NAME

--- a/pkg/fakedevice/fakedevice.go
+++ b/pkg/fakedevice/fakedevice.go
@@ -2,7 +2,6 @@ package fakedevice
 
 import (
 	"fmt"
-	"path/filepath"
 	"strings"
 
 	"k8s.io/klog/v2"
@@ -10,10 +9,10 @@ import (
 )
 
 // MakeEnv creates the environment variable in the format: <resource-prefix>_<device-id>_<device-file>=<numanode-id>
-func MakeEnv(resourceName, fpath string, dev pluginapi.Device) map[string]string {
+func MakeEnv(resourceName string, dev pluginapi.Device) map[string]string {
 	env := make(map[string]string)
 
-	key := fmt.Sprintf("%s_%s_%s", resourceName, dev.ID, filepath.Base(fpath))
+	key := fmt.Sprintf("%s_%s", resourceName, dev.ID)
 	key = strings.Map(func(r rune) rune {
 		if r == '.' || r == '/' {
 			return -1

--- a/pkg/fakedevice/fakedevice_test.go
+++ b/pkg/fakedevice/fakedevice_test.go
@@ -24,7 +24,7 @@ var _ = Describe("FakeDevice", func() {
 				Health:   pluginapi.Healthy,
 				Topology: &pluginapi.TopologyInfo{Nodes: []*pluginapi.NUMANode{{ID: 0}}},
 			}
-			env := fakedevice.MakeEnv(resourceName, "/dev/fake0", dev)
+			env := fakedevice.MakeEnv(resourceName, dev)
 			Expect(env).To(Not(BeNil()))
 			for key := range env {
 				keyUpper := strings.ToUpper(key)
@@ -38,7 +38,7 @@ var _ = Describe("FakeDevice", func() {
 				Health:   pluginapi.Healthy,
 				Topology: &pluginapi.TopologyInfo{Nodes: []*pluginapi.NUMANode{{ID: 0}}},
 			}
-			env := fakedevice.MakeEnv(resourceName, "/dev/fake1", dev)
+			env := fakedevice.MakeEnv(resourceName, dev)
 			Expect(env).To(Not(BeNil()))
 			for key := range env {
 				Expect(key).To(Not(ContainSubstring("/")))
@@ -51,7 +51,7 @@ var _ = Describe("FakeDevice", func() {
 				Health:   pluginapi.Healthy,
 				Topology: &pluginapi.TopologyInfo{Nodes: []*pluginapi.NUMANode{{ID: 0}}},
 			}
-			env := fakedevice.MakeEnv(resourceName, "/dev/fake2", dev)
+			env := fakedevice.MakeEnv(resourceName, dev)
 			Expect(env).To(Not(BeNil()))
 			for key := range env {
 				Expect(key).To(Not(ContainSubstring(".")))
@@ -64,7 +64,7 @@ var _ = Describe("FakeDevice", func() {
 				Health:   pluginapi.Healthy,
 				Topology: &pluginapi.TopologyInfo{Nodes: []*pluginapi.NUMANode{{ID: 0}}},
 			}
-			env := fakedevice.MakeEnv(resourceName, "/dev/fake3", dev)
+			env := fakedevice.MakeEnv(resourceName, dev)
 			Expect(env).To(Not(BeNil()))
 			for key := range env {
 				Expect(key).To(HavePrefix(resourcePrefix))

--- a/test/e2e/sample_device_plugin.go
+++ b/test/e2e/sample_device_plugin.go
@@ -14,10 +14,13 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 )
 
+const (
+	DefaultDevicePath = "/dev/null"
+)
+
 type deviceRequest struct {
-	Name       string
-	Amount     int64
-	DeviceName string
+	Name   string
+	Amount int64
 }
 
 var _ = Describe("sample device plugin", func() {
@@ -72,7 +75,7 @@ var _ = Describe("sample device plugin", func() {
 					Expect(env).To(HavePrefix(strings.ToUpper(devName)))
 				}
 
-				data, err := ExecCommandOnPod(testpod, []string{"/bin/sh", "-c", fmt.Sprintf("/bin/stat -c %%F %s", devReq.DeviceName)})
+				data, err := ExecCommandOnPod(testpod, []string{"/bin/sh", "-c", fmt.Sprintf("/bin/stat -c %%F %s", DefaultDevicePath)})
 				Expect(err).ToNot(HaveOccurred())
 				for _, devDesc := range strings.Split(string(data), "\n") {
 					line := strings.TrimSpace(devDesc)
@@ -87,16 +90,14 @@ var _ = Describe("sample device plugin", func() {
 		},
 			table.Entry("a single device A", []deviceRequest{
 				{
-					Name:       "example.com/deviceA",
-					Amount:     1,
-					DeviceName: "/dev/tty1?",
+					Name:   "example.com/deviceA",
+					Amount: 1,
 				},
 			}),
 			table.Entry("a single device B", []deviceRequest{
 				{
-					Name:       "example.com/deviceB",
-					Amount:     1,
-					DeviceName: "/dev/tty2?",
+					Name:   "example.com/deviceB",
+					Amount: 1,
 				},
 			}),
 		)


### PR DESCRIPTION
We currently rely on using serial ports as devices. But this can be
limiting because of there being limited serial port available on the
We are forced to keep track of the device count to make sure
that a unique serial port device corresponds to a device exposed
to the kubelet. In addition to that, this puts an implied limit
on the number of devices that can be configured and subsequently
allocated by the sample-device-plugin.
    
In order to avoid this and prevent any future unexpected bugs,
we use `/dev/null` as a device to be allocated from the host to
the container. This gives us flexibility and freedom to emulate
any number of devices. By doing so, the number of devices are
exposed are only dependent on device plugin config and not any
other underlying limiting factor.
    
This patch also removes references to the devicename in the config
as that is no longer needed.

We also update image tag to include latest changes.