### PR TITLE
overhaul the  sample-device-plugin package structure 

### DIFF
--- a/cmd/deviceplugin/main.go
+++ b/cmd/deviceplugin/main.go
@@ -85,17 +85,8 @@ func main() {
 	klog.InitFlags(nil)
 	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
 	pflag.StringVarP(&configDirPath, "config-dir", "C", "", "directory which contains the device plugin configuration files")
-	pflag.StringVarP(&sInfo.resourceName, "resource", "r", "", "device plugin resource name")
+	pflag.StringVarP(&sInfo.resourceName, "resource", "r", defaultResName(), "device plugin resource name")
 	pflag.Parse()
-
-	if sInfo.resourceName == "" {
-		sInfo.resourceName = os.Getenv(EnvVarResourceName)
-		klog.Infof("Resource name configured from environ: %q", sInfo.resourceName)
-	}
-	if sInfo.resourceName == "" {
-		klog.Infof("No resource name configured - nothing to do")
-		os.Exit(0)
-	}
 
 	hostname, err := os.Hostname()
 	if err != nil {
@@ -156,4 +147,15 @@ func main() {
 		klog.Fatalf("Unable to register the DevicePlugin, Error: %v", err)
 	}
 	select {}
+}
+
+func defaultResName() string {
+	devResourceName, ok := os.LookupEnv(EnvVarResourceName)
+	if !ok {
+		klog.Infof("no resource name configured - nothing to do")
+		os.Exit(0)
+	}
+
+	klog.Infof("resource name configured from environment: %q", devResourceName)
+	return devResourceName
 }

--- a/cmd/deviceplugin/main.go
+++ b/cmd/deviceplugin/main.go
@@ -18,22 +18,19 @@ package main
 
 import (
 	"flag"
-	"fmt"
-	"github.com/k8stopologyawareschedwg/sample-device-plugin/pkg/deviceconfig"
-	"github.com/k8stopologyawareschedwg/sample-device-plugin/pkg/stub"
 	"os"
-	"time"
 
-	"github.com/spf13/pflag"
 	"k8s.io/klog/v2"
 
-	pluginapi "k8s.io/kubelet/pkg/apis/deviceplugin/v1beta1"
-	dm "k8s.io/kubernetes/pkg/kubelet/cm/devicemanager"
+	"github.com/spf13/pflag"
+
+	"github.com/k8stopologyawareschedwg/sample-device-plugin/pkg/deviceconfig"
+	"github.com/k8stopologyawareschedwg/sample-device-plugin/pkg/deviceplugin"
+	"github.com/k8stopologyawareschedwg/sample-device-plugin/pkg/stub"
 )
 
 const (
 	EnvVarResourceName = "DEVICE_RESOURCE_NAME"
-	socketDir          = "/var/lib/kubelet/device-plugins"
 )
 
 func main() {
@@ -55,20 +52,10 @@ func main() {
 	if err != nil {
 		klog.Fatalf("%v", err)
 	}
-	klog.Infof("pluginSocksDir: %s", socketDir)
 
-	socketPath := socketDir + "/dp." + fmt.Sprintf("%d", time.Now().Unix())
-
-	dp1 := dm.NewDevicePluginStub(sInfo.APIDevsConfig, socketPath, sInfo.ResourceName, false, false)
-	if err := dp1.Start(); err != nil {
-		klog.Fatalf("Unable to start the DevicePlugin, Error: %v", err)
-
+	if err = deviceplugin.Execute(sInfo, "", false, false); err != nil {
+		klog.Fatalf("%v", err)
 	}
-	dp1.SetAllocFunc(sInfo.GetStubAllocFunc())
-	if err := dp1.Register(pluginapi.KubeletSocket, sInfo.ResourceName, pluginapi.DevicePluginPath); err != nil {
-		klog.Fatalf("Unable to register the DevicePlugin, Error: %v", err)
-	}
-	select {}
 }
 
 func defaultResName() string {

--- a/pkg/deviceconfig/deviceconfig.go
+++ b/pkg/deviceconfig/deviceconfig.go
@@ -1,0 +1,73 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package deviceconfig
+
+import (
+	"fmt"
+	"io/ioutil"
+	"path/filepath"
+	"strings"
+
+	"gopkg.in/yaml.v2"
+	pluginapi "k8s.io/kubelet/pkg/apis/deviceplugin/v1beta1"
+)
+
+type SampleDevice struct {
+	ID       string `yaml:"id"`
+	Healthy  bool   `yaml:"healthy"`
+	NUMANode int    `yaml:"numanode"`
+}
+
+func (dc *SampleDevice) ToHealthy() string {
+	if dc.Healthy {
+		return pluginapi.Healthy
+	}
+	return pluginapi.Unhealthy
+}
+
+type NodesDevices struct {
+	Devices map[string][]SampleDevice `yaml:"devices"`
+}
+
+func Parse(path, resName string) (*NodesDevices, error) {
+	var conf *NodesDevices
+	if path == "" {
+		return nil, fmt.Errorf("deviceconfig path must be provided - nothing to do")
+	}
+	fullPath := getDevPath(path, resName)
+
+	b, err := ioutil.ReadFile(fullPath)
+	if err != nil {
+		return nil, err
+	}
+
+	err = yaml.Unmarshal(b, &conf)
+	if err != nil {
+		return nil, err
+	}
+	return conf, nil
+}
+
+func getDevPath(configDirPath, resourceName string) string {
+	configFileName := fmt.Sprintf("%s.yaml", strings.Map(func(r rune) rune {
+		if r == '.' || r == '/' {
+			return '_'
+		}
+		return r
+	}, resourceName))
+	return filepath.Join(configDirPath, configFileName)
+}

--- a/pkg/deviceconfig/deviceconfig_test.go
+++ b/pkg/deviceconfig/deviceconfig_test.go
@@ -1,0 +1,141 @@
+package deviceconfig
+
+import (
+	"github.com/google/go-cmp/cmp"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestParse(t *testing.T) {
+	testCases := []struct {
+		name         string
+		conf         []byte
+		resName      string
+		confFileName string
+		expected     *NodesDevices
+	}{
+		{
+			name: "valid config without wildcard",
+			conf: []byte(
+				`
+devices:
+   kind-control-plane:
+     - id: DevA1
+       healthy: true
+       numanode: 0
+     - id: DevA2
+       healthy: true
+       numanode: 1
+     - id: DevA3
+       healthy: false
+       numanode: 1
+`),
+			resName:      "test/dev",
+			confFileName: "test_dev.yaml",
+			expected: &NodesDevices{
+				Devices: map[string][]SampleDevice{
+					"kind-control-plane": {
+						{
+							ID:       "DevA1",
+							Healthy:  true,
+							NUMANode: 0,
+						},
+						{
+							ID:       "DevA2",
+							Healthy:  true,
+							NUMANode: 1,
+						},
+						{
+							ID:       "DevA3",
+							Healthy:  false,
+							NUMANode: 1,
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "valid config with wildcard",
+			conf: []byte(
+				`
+devices:
+  '*':
+    - id: DevA1
+      healthy: true
+      numanode: 0
+    - id: DevA2
+      healthy: true
+      numanode: 1
+    - id: DevA3
+      healthy: true
+      numanode: 1
+`),
+			resName:      "prefix/test.dev",
+			confFileName: "prefix_test_dev.yaml",
+			expected: &NodesDevices{
+				Devices: map[string][]SampleDevice{
+					"*": {
+						{
+							ID:       "DevA1",
+							Healthy:  true,
+							NUMANode: 0,
+						},
+						{
+							ID:       "DevA2",
+							Healthy:  true,
+							NUMANode: 1,
+						},
+						{
+							ID:       "DevA3",
+							Healthy:  true,
+							NUMANode: 1,
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "invalid config",
+			conf: []byte(
+				`
+devices:
+  '*':
+    - fail: DevA1
+      wrong: true
+`),
+			resName:      "test/fail/dev",
+			confFileName: "test_fail_dev.yaml",
+			expected: &NodesDevices{
+				Devices: map[string][]SampleDevice{"*": {{}}}},
+		},
+	}
+
+	confDir, err := ioutil.TempDir("", "")
+	if err != nil {
+		t.Fatalf("failed to open temporary dir")
+	}
+
+	defer func(path string) {
+		err := os.RemoveAll(path)
+		if err != nil {
+			t.Fatalf("failed to delete dir %q", path)
+		}
+	}(confDir)
+
+	for _, tc := range testCases {
+		t.Logf("test %s", tc.name)
+		fullFilePath := filepath.Join(confDir, tc.confFileName)
+		if err := ioutil.WriteFile(fullFilePath, tc.conf, 0644); err != nil {
+			t.Fatalf("failed to write to %q", fullFilePath)
+		}
+		devices, err := Parse(confDir, tc.resName)
+		if err != nil {
+			t.Errorf("failed to parse conf file %q with resource name %q; error: %v", fullFilePath, tc.resName, err)
+		}
+		if diff := cmp.Diff(tc.expected, devices); diff != "" {
+			t.Errorf("configuration mismatch; diff %v", diff)
+		}
+	}
+}

--- a/pkg/deviceplugin/deviceplugin.go
+++ b/pkg/deviceplugin/deviceplugin.go
@@ -1,0 +1,48 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package deviceplugin
+
+import (
+	"fmt"
+	"time"
+
+	"k8s.io/klog/v2"
+	pluginapi "k8s.io/kubelet/pkg/apis/deviceplugin/v1beta1"
+	dm "k8s.io/kubernetes/pkg/kubelet/cm/devicemanager"
+
+	"github.com/k8stopologyawareschedwg/sample-device-plugin/pkg/stub"
+)
+
+const socketDir = "/var/lib/kubelet/device-plugins"
+
+func Execute(sInfo *stub.Info, socket string, preStartContainerFlag bool, getPreferredAllocationFlag bool) error {
+	if socket == "" {
+		klog.Infof("pluginSocksDir: %s", socketDir)
+		socket = socketDir + "/dp." + fmt.Sprintf("%d", time.Now().Unix())
+	}
+
+	dp1 := dm.NewDevicePluginStub(sInfo.APIDevsConfig, socket, sInfo.ResourceName, preStartContainerFlag, getPreferredAllocationFlag)
+	if err := dp1.Start(); err != nil {
+		return fmt.Errorf("unable to start the DevicePlugin; error: %w", err)
+	}
+
+	dp1.SetAllocFunc(sInfo.GetStubAllocateFunc())
+	if err := dp1.Register(pluginapi.KubeletSocket, sInfo.ResourceName, pluginapi.DevicePluginPath); err != nil {
+		return fmt.Errorf("unable to register the DevicePlugin; error: %w", err)
+	}
+	select {}
+}

--- a/pkg/stub/stub.go
+++ b/pkg/stub/stub.go
@@ -1,0 +1,130 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package stub
+
+import (
+	"fmt"
+	"os"
+
+	"k8s.io/klog/v2"
+	pluginapi "k8s.io/kubelet/pkg/apis/deviceplugin/v1beta1"
+
+	"github.com/k8stopologyawareschedwg/sample-device-plugin/pkg/deviceconfig"
+	"github.com/k8stopologyawareschedwg/sample-device-plugin/pkg/fakedevice"
+)
+
+const DefaultDevicePath = "/dev/null"
+
+type Info struct {
+	ResourceName  string
+	APIDevsConfig []*pluginapi.Device
+	devicePath    string
+	nodeName      string
+}
+
+// GetStubAllocFunc creates and returns allocation response for the input allocate request
+func (sInfo *Info) GetStubAllocFunc() func(r *pluginapi.AllocateRequest, devs map[string]pluginapi.Device) (*pluginapi.AllocateResponse, error) {
+	return func(r *pluginapi.AllocateRequest, devs map[string]pluginapi.Device) (*pluginapi.AllocateResponse, error) {
+		var responses pluginapi.AllocateResponse
+		for _, req := range r.ContainerRequests {
+			response := &pluginapi.ContainerAllocateResponse{}
+			env := make(map[string]string)
+
+			for _, requestID := range req.DevicesIDs {
+				dev, ok := devs[requestID]
+				if !ok {
+					return nil, fmt.Errorf("invalid allocation request with non-existing device %s", requestID)
+				}
+
+				if dev.Health != pluginapi.Healthy {
+					return nil, fmt.Errorf("invalid allocation request with unhealthy device: %s", requestID)
+				}
+
+				for key, val := range fakedevice.MakeEnv(sInfo.ResourceName, dev) {
+					env[key] = val
+				}
+
+				response.Devices = append(response.Devices, &pluginapi.DeviceSpec{
+					ContainerPath: DefaultDevicePath,
+					HostPath:      DefaultDevicePath,
+					Permissions:   "rw",
+				})
+			}
+			response.Envs = env
+			responses.ContainerResponses = append(responses.ContainerResponses, response)
+		}
+		return &responses, nil
+	}
+}
+
+func New(resourceName string, nodeDevicesConfig *deviceconfig.NodesDevices, devicePath, nodeName string) (*Info, error) {
+	if devicePath == "" {
+		klog.Infof("using default device type path: %q", DefaultDevicePath)
+		devicePath = DefaultDevicePath
+	}
+
+	if nodeName == "" {
+		var err error
+		nodeName, err = os.Hostname()
+		if err != nil {
+			return nil, fmt.Errorf("unable to get the hostname, error: %v", err)
+		}
+	}
+
+	devsConf, ok := nodeDevicesConfig.Devices[nodeName]
+	if !ok {
+		devsConf, ok = nodeDevicesConfig.Devices["*"]
+	}
+	if !ok {
+		return nil, fmt.Errorf("no devices configured for %q - nothing to do", nodeName)
+	}
+	klog.V(4).Infof("node: %q configured devices: %v", nodeName, devsConf)
+
+	devs := MakePluginApiDevices(devsConf)
+	if len(devs) == 0 {
+		return nil, fmt.Errorf("no devices enabled for resource %q - nothing to do", resourceName)
+	}
+	klog.V(4).Infof("devices: %v", devs)
+
+	return &Info{
+		ResourceName:  resourceName,
+		APIDevsConfig: devs,
+		devicePath:    devicePath,
+		nodeName:      nodeName,
+	}, nil
+}
+
+func MakePluginApiDevices(devsConf []deviceconfig.SampleDevice) []*pluginapi.Device {
+	var devs []*pluginapi.Device
+	for _, devConf := range devsConf {
+		var topo *pluginapi.TopologyInfo
+		if devConf.NUMANode != -1 {
+			topo = &pluginapi.TopologyInfo{
+				Nodes: []*pluginapi.NUMANode{
+					{ID: int64(devConf.NUMANode)},
+				},
+			}
+		}
+		dev := &pluginapi.Device{
+			ID:       devConf.ID,
+			Health:   devConf.ToHealthy(),
+			Topology: topo,
+		}
+		devs = append(devs, dev)
+	}
+	return devs
+}

--- a/pkg/stub/stub.go
+++ b/pkg/stub/stub.go
@@ -36,8 +36,8 @@ type Info struct {
 	nodeName      string
 }
 
-// GetStubAllocFunc creates and returns allocation response for the input allocate request
-func (sInfo *Info) GetStubAllocFunc() func(r *pluginapi.AllocateRequest, devs map[string]pluginapi.Device) (*pluginapi.AllocateResponse, error) {
+// GetStubAllocateFunc creates and returns allocation response for the input allocate request
+func (sInfo *Info) GetStubAllocateFunc() func(r *pluginapi.AllocateRequest, devs map[string]pluginapi.Device) (*pluginapi.AllocateResponse, error) {
 	return func(r *pluginapi.AllocateRequest, devs map[string]pluginapi.Device) (*pluginapi.AllocateResponse, error) {
 		var responses pluginapi.AllocateResponse
 		for _, req := range r.ContainerRequests {

--- a/pkg/stub/stub_suite_test.go
+++ b/pkg/stub/stub_suite_test.go
@@ -1,0 +1,13 @@
+package stub_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestResources(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Stub Suite")
+}

--- a/pkg/stub/stub_test.go
+++ b/pkg/stub/stub_test.go
@@ -1,0 +1,47 @@
+package stub_test
+
+import (
+	"github.com/k8stopologyawareschedwg/sample-device-plugin/pkg/deviceconfig"
+	"github.com/k8stopologyawareschedwg/sample-device-plugin/pkg/stub"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Stub tests", func() {
+	When(" initialized new stub object", func() {
+		devices := &deviceconfig.NodesDevices{
+			Devices: map[string][]deviceconfig.SampleDevice{
+				"node1": {
+					{
+						ID:       "2",
+						Healthy:  false,
+						NUMANode: 0,
+					},
+					{
+						ID:       "3",
+						Healthy:  true,
+						NUMANode: 1,
+					},
+				},
+				"node2": {
+					{
+						ID:       "4",
+						Healthy:  true,
+						NUMANode: 1,
+					},
+					{
+						ID:       "5",
+						Healthy:  false,
+						NUMANode: 1,
+					},
+				},
+			}}
+		sInfo, err := stub.New("devA", devices, "dev/null", "node2")
+		Expect(err).ToNot(HaveOccurred())
+		It("should build the correct api plugin devices config", func() {
+			Expect(sInfo.APIDevsConfig[0].ID).To(Equal("4"))
+			Expect(sInfo.APIDevsConfig[1].Health).To(Equal("Unhealthy"))
+			Expect(sInfo.APIDevsConfig[1].Topology.Nodes[0].ID).To(Equal(int64(1)))
+		})
+	})
+})


### PR DESCRIPTION
This PR intended to move the business logic out of ```main.go``` and split it into separate, flexible, portable packages.
More details are listed in each commit.


- [x] unit-tests