### PR TITLE
manifests: set args using manifests instead of dockerfile

### DIFF
--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -14,4 +14,4 @@
 
 FROM busybox
 ADD bin/deviceplugin /bin/deviceplugin
-ENTRYPOINT ["/bin/deviceplugin", "--alsologtostderr", "-C", "/etc/devices"]
+ENTRYPOINT ["/bin/deviceplugin"]

--- a/manifests/devicepluginA-ds.yaml
+++ b/manifests/devicepluginA-ds.yaml
@@ -17,6 +17,11 @@ spec:
       containers:
       - name: device-plugin-a-container
         image: quay.io/k8stopologyawareschedwg/sample-device-plugin:v0.1.2
+        command:
+          - /bin/deviceplugin
+        args:
+          - --alsologtostderr
+          - --config-dir=/etc/devices
         imagePullPolicy: IfNotPresent
         env:
         - name: DEVICE_RESOURCE_NAME

--- a/manifests/devicepluginB-ds.yaml
+++ b/manifests/devicepluginB-ds.yaml
@@ -17,6 +17,11 @@ spec:
       containers:
       - name: device-plugin-b-container
         image: quay.io/k8stopologyawareschedwg/sample-device-plugin:v0.1.2
+        command:
+          - /bin/deviceplugin
+        args:
+          - --alsologtostderr
+          - --config-dir=/etc/devices
         imagePullPolicy: IfNotPresent
         env:
         - name: DEVICE_RESOURCE_NAME

--- a/manifests/devicepluginC-ds.yaml
+++ b/manifests/devicepluginC-ds.yaml
@@ -17,6 +17,11 @@ spec:
       containers:
       - name: device-plugin-a-container
         image: quay.io/k8stopologyawareschedwg/sample-device-plugin:v0.1.2
+        command:
+          - /bin/deviceplugin
+        args:
+          - --alsologtostderr
+          - --config-dir=/etc/devices
         imagePullPolicy: IfNotPresent
         env:
         - name: DEVICE_RESOURCE_NAME


### PR DESCRIPTION
Set the container's arguments from the DaemonSet's manifest is more K8S native way than setting them via the Dockerfile. In addition it'll allow greater flexibility and more observability, since all the configurations are under a single file.

Signed-off-by: Talor Itzhak <titzhak@redhat.com>