### PR TITLE
compatibility enhancements: reconnect support, autogenerate devs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
-/bin
+bin
+_out

--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,10 @@ BUILDENVVAR = CGO_ENABLED=0
 RUNTIME ?= podman
 REPOOWNER ?= k8stopologyawareschedwg
 IMAGENAME ?= sample-device-plugin
+IMAGENAME_WORKLOAD ?= sample-device-workload
 IMAGETAG ?= latest
 SAMPLE_DEVICE_PLUGIN_CONTAINER_IMAGE ?= quay.io/${REPOOWNER}/${IMAGENAME}:${IMAGETAG}
+SAMPLE_DEVICE_WORKLOAD_CONTAINER_IMAGE ?= quay.io/${REPOOWNER}/${IMAGENAME_WORKLOAD}:${IMAGETAG}
 KUSTOMIZE_DEPLOY_DIR ?= default
 
 .PHONY: all
@@ -32,6 +34,11 @@ image: build
 	@echo "building image"
 	$(RUNTIME) build -f images/Dockerfile -t $(SAMPLE_DEVICE_PLUGIN_CONTAINER_IMAGE) .
 
+.PHONY: image-workload
+image-workload:
+	@echo "building image for sample workload"
+	$(RUNTIME) build -f images/workload/Dockerfile -t $(SAMPLE_DEVICE_WORKLOAD_CONTAINER_IMAGE) images/workload
+
 .PHONY: unit-tests
 unit-tests:
 	@echo "running unit tests"
@@ -41,6 +48,11 @@ unit-tests:
 push: image
 	@echo "pushing image"
 	$(RUNTIME) push $(SAMPLE_DEVICE_PLUGIN_CONTAINER_IMAGE)
+
+.PHONY: push-workload
+push-workload: image-workload
+	@echo "pushing image for sample workload"
+	$(RUNTIME) push $(SAMPLE_DEVICE_WORKLOAD_CONTAINER_IMAGE)
 
 .PHONY: deploy
 deploy:

--- a/deployment/base/devicepluginA-ds/devicepluginA-ds.yaml
+++ b/deployment/base/devicepluginA-ds/devicepluginA-ds.yaml
@@ -2,6 +2,8 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: device-plugin-a-ds
+  labels:
+    app: sample-device-plugin
 spec:
   selector:
       matchLabels:

--- a/images/workload/Dockerfile
+++ b/images/workload/Dockerfile
@@ -1,0 +1,3 @@
+FROM busybox
+COPY entrypoint.sh /bin/workload
+ENTRYPOINT ["/bin/workload"]

--- a/images/workload/entrypoint.sh
+++ b/images/workload/entrypoint.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+# 1. validate resource. We can't predict, so we only check something was set, anything is fine
+if [ -z "${_SAMPLE_DEVICE_RESOURCE}" ]; then
+	echo "missing resource"
+	exit 1
+fi
+
+# 2. validate device assignment
+if [ -z "${_SAMPLE_DEVICE_ASSIGNED}" ]; then
+	echo "missing device"
+	exit 2
+fi
+
+DEV=$( echo ${_SAMPLE_DEVICE_ASSIGNED} | egrep '^Dev-[0-9]+$' )
+if [ -z "${DEV}" ]; then
+	echo "malformed device: ${_SAMPLE_DEVICE_ASSIGNED}"
+	exit 4
+fi
+
+# 3. print validated device - in a k8s compatible way
+echo stub devices: ${DEV}
+
+# 4. sleep forever if we got this far
+sleep inf

--- a/images/workload/pod.yaml
+++ b/images/workload/pod.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    app: sample-device-workload
+  name: sample-device-workload
+  namespace: sample-device-plugin
+spec:
+  containers:
+    - command:
+        - /bin/workload
+      image: quay.io/k8stopologyawareschedwg/sample-device-workload:latest
+      imagePullPolicy: Always
+      name: sample-device-workload
+      resources:
+        limits:
+          cpu: "1"
+          memory: 1Gi
+          example.com/deviceA: 1
+        requests:
+          cpu: "1"
+          memory: 1Gi
+          example.com/deviceA: 1

--- a/pkg/deviceconfig/deviceconfig.go
+++ b/pkg/deviceconfig/deviceconfig.go
@@ -44,7 +44,7 @@ type NodesDevices struct {
 }
 
 func Parse(path, resName string) (*NodesDevices, error) {
-	var conf *NodesDevices
+	var conf NodesDevices
 	if path == "" {
 		return nil, fmt.Errorf("deviceconfig path must be provided - nothing to do")
 	}
@@ -59,7 +59,23 @@ func Parse(path, resName string) (*NodesDevices, error) {
 	if err != nil {
 		return nil, err
 	}
-	return conf, nil
+	return &conf, nil
+}
+
+func Generate(count int) *NodesDevices {
+	devs := []SampleDevice{}
+	for idx := 0; idx < count; idx++ {
+		devs = append(devs, SampleDevice{
+			ID:       fmt.Sprintf("Dev-%d", idx),
+			Healthy:  true,
+			NUMANode: -1,
+		})
+	}
+	return &NodesDevices{
+		Devices: map[string][]SampleDevice{
+			"*": devs,
+		},
+	}
 }
 
 func getDevPath(configDirPath, resourceName string) string {

--- a/pkg/deviceconfig/deviceconfig_test.go
+++ b/pkg/deviceconfig/deviceconfig_test.go
@@ -139,3 +139,55 @@ devices:
 		}
 	}
 }
+
+func TestGenerate(t *testing.T) {
+	testCases := []struct {
+		name     string
+		count    int
+		expected *NodesDevices
+	}{
+		{
+			name:  "no devices",
+			count: 0,
+			expected: &NodesDevices{
+				Devices: map[string][]SampleDevice{
+					"*": {},
+				},
+			},
+		},
+		{
+			name:  "typical devices amount",
+			count: 3,
+			expected: &NodesDevices{
+				Devices: map[string][]SampleDevice{
+					"*": {
+						{
+							ID:       "Dev-0",
+							Healthy:  true,
+							NUMANode: -1,
+						},
+						{
+							ID:       "Dev-1",
+							Healthy:  true,
+							NUMANode: -1,
+						},
+						{
+							ID:       "Dev-2",
+							Healthy:  true,
+							NUMANode: -1,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := Generate(tc.count)
+			if diff := cmp.Diff(tc.expected, got); diff != "" {
+				t.Errorf("generation mismatch; diff %v", diff)
+			}
+		})
+	}
+}

--- a/pkg/deviceconfig/deviceconfig_test.go
+++ b/pkg/deviceconfig/deviceconfig_test.go
@@ -1,11 +1,12 @@
 package deviceconfig
 
 import (
-	"github.com/google/go-cmp/cmp"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestParse(t *testing.T) {
@@ -125,18 +126,19 @@ devices:
 	}(confDir)
 
 	for _, tc := range testCases {
-		t.Logf("test %s", tc.name)
-		fullFilePath := filepath.Join(confDir, tc.confFileName)
-		if err := ioutil.WriteFile(fullFilePath, tc.conf, 0644); err != nil {
-			t.Fatalf("failed to write to %q", fullFilePath)
-		}
-		devices, err := Parse(confDir, tc.resName)
-		if err != nil {
-			t.Errorf("failed to parse conf file %q with resource name %q; error: %v", fullFilePath, tc.resName, err)
-		}
-		if diff := cmp.Diff(tc.expected, devices); diff != "" {
-			t.Errorf("configuration mismatch; diff %v", diff)
-		}
+		t.Run(tc.name, func(t *testing.T) {
+			fullFilePath := filepath.Join(confDir, tc.confFileName)
+			if err := ioutil.WriteFile(fullFilePath, tc.conf, 0644); err != nil {
+				t.Fatalf("failed to write to %q", fullFilePath)
+			}
+			devices, err := Parse(confDir, tc.resName)
+			if err != nil {
+				t.Errorf("failed to parse conf file %q with resource name %q; error: %v", fullFilePath, tc.resName, err)
+			}
+			if diff := cmp.Diff(tc.expected, devices); diff != "" {
+				t.Errorf("configuration mismatch; diff %v", diff)
+			}
+		})
 	}
 }
 

--- a/pkg/fakedevice/fakedevice.go
+++ b/pkg/fakedevice/fakedevice.go
@@ -8,9 +8,16 @@ import (
 	pluginapi "k8s.io/kubelet/pkg/apis/deviceplugin/v1beta1"
 )
 
-// MakeEnv creates the environment variable in the format: <resource-prefix>_<device-id>_<device-file>=<numanode-id>
+// MakeEnv creates the following environment variables
+// - _SAMPLE_DEVICE_RESOURCE=<resource-name>
+// - _SAMPLE_DEVICE_ASSIGNED=<device-id>
+// - _SAMPLE_DEVICE_NUMA_LOCALITY=<numanode-id>
+// - <resource-prefix>_<device-id>_<device-file>=<numanode-id>
 func MakeEnv(resourceName string, dev pluginapi.Device) map[string]string {
-	env := make(map[string]string)
+	env := map[string]string{
+		"_SAMPLE_DEVICE_RESOURCE": resourceName,
+		"_SAMPLE_DEVICE_ASSIGNED": dev.ID,
+	}
 
 	key := fmt.Sprintf("%s_%s", resourceName, dev.ID)
 	key = strings.Map(func(r rune) rune {
@@ -27,6 +34,8 @@ func MakeEnv(resourceName string, dev pluginapi.Device) map[string]string {
 	}
 	klog.Infof("Creating environment variables key=%q val=%q", key, val)
 	env[key] = val
+
+	env["_SAMPLE_DEVICE_NUMA_LOCALITY"] = val
 
 	return env
 }

--- a/pkg/fakedevice/fakedevice_test.go
+++ b/pkg/fakedevice/fakedevice_test.go
@@ -12,8 +12,9 @@ import (
 )
 
 const (
-	resourceName   = "io.openshift/fakedev"
-	resourcePrefix = "IOOPENSHIFTFAKEDEV"
+	resourceName       = "io.openshift/fakedev"
+	resourcePrefix     = "IOOPENSHIFTFAKEDEV"
+	sampleDevicePrefix = "_SAMPLE_DEVICE"
 )
 
 var _ = Describe("FakeDevice", func() {
@@ -67,7 +68,10 @@ var _ = Describe("FakeDevice", func() {
 			env := fakedevice.MakeEnv(resourceName, dev)
 			Expect(env).To(Not(BeNil()))
 			for key := range env {
-				Expect(key).To(HavePrefix(resourcePrefix))
+				Expect(key).To(Or(
+					HavePrefix(resourcePrefix),
+					HavePrefix(sampleDevicePrefix),
+				))
 			}
 		})
 	})


### PR DESCRIPTION
enhancements for better compatibility with the u/s official sample device plugin:
- trivial reconnect support, just the bare minimum we need to handle the most basic scenarios for testing
- autogenerate, if asked to, u/s compatible trivial devices. Note the much more powerful configuration file support is fuly kept and still the preferred option